### PR TITLE
Fix flywayInfo displays nothing

### DIFF
--- a/src/main/scala/io/github/davidmweber/FlywayPlugin.scala
+++ b/src/main/scala/io/github/davidmweber/FlywayPlugin.scala
@@ -188,10 +188,9 @@ object FlywayPlugin extends AutoPlugin {
       flywayDefaults := withPrepared(flywayClasspath.value, streams.value)(Flyway.configure()),
       flywayMigrate := flywayDefaults.value.configure(flywayConfig.value).migrate(),
       flywayValidate := flywayDefaults.value.configure(flywayConfig.value).validate(),
-      flywayInfo := Def.task {
+      flywayInfo := {
         val info = flywayDefaults.value.configure(flywayConfig.value).info()
         streams.value.log.info(MigrationInfoDumper.dumpToAsciiTable(info.all()))
-        info
       },
       flywayRepair := flywayDefaults.value.configure(flywayConfig.value).repair(),
       flywayClean := flywayDefaults.value.configure(flywayConfig.value).clean(),

--- a/src/sbt-test/flyway-sbt/test1/test
+++ b/src/sbt-test/flyway-sbt/test1/test
@@ -3,6 +3,8 @@
 > 'eval System.setProperty("flyway.placeholders.name", "James")'
 > flywayClean
 > flywayMigrate
+> flywayInfo
 > 'eval System.setProperty("flyway.locations", "filesystem:src/main/resources/db/migration,filesystem:src/test/resources/db/migration")'
 > test:flywayClean
 > test:flywayMigrate
+> test:flywayInfo


### PR DESCRIPTION
Before:
![2019-10-06_10-24](https://user-images.githubusercontent.com/1237897/66263082-31011080-e828-11e9-8220-80e0d1de61e5.png)

After:
![2019-10-06_10-27](https://user-images.githubusercontent.com/1237897/66263085-365e5b00-e828-11e9-9a53-85bfc202d667.png)

`Def.task {}` is used to separate the implementation of a task from the binding.
Normal task definition needs simply `{}`.

https://www.scala-sbt.org/1.x/docs/Tasks.html#Separating+implementations

`Def.task {}.value` probably provides same result.