### PR TITLE
Avoid triggering compile tasks before flyway task

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,10 @@ libraryDependencies += "org.hsqldb" % "hsqldb" % "2.5.0"
 flywayUrl := "jdbc:hsqldb:file:target/flyway_sample;shutdown=true"
 flywayUser := "SA"
 flywayPassword := ""
-flywayLocations += "db/migration"
+flywayLocations := Seq("filesystem:src/main/resources/db/migration")
 flywayUrl in Test := "jdbc:hsqldb:file:target/flyway_sample;shutdown=true"
 flywayUser in Test := "SA"
+flywayLocations in Test := Seq("filesystem:src/main/resources/db/migration")
 flywayPassword in Test := ""
 
 ```


### PR DESCRIPTION
Many flyway users also generate code from the schema. They have to take care to "Prevent compile task being triggered prior to a flyway task being run #10" Adapted the example in the readme accordingly, so that many can avoid this pitfall.